### PR TITLE
Parameterize Behavior File for json_joint_publisher

### DIFF
--- a/sami_sim/scripts/json_joint_publisher.py
+++ b/sami_sim/scripts/json_joint_publisher.py
@@ -10,12 +10,15 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 
-behavior = 'TEST.json' # Change this to the desired behavior file
+package_name = 'sami_sim'
 
 class RobotJointPublisher(Node):
     def __init__(self):
         super().__init__('robot_joint_publisher')
         self.publisher = self.create_publisher(JointState, '/joint_states', 10)
+
+        # Parameter declaration
+        self.declare_parameter('behavior', 'TEST.json')
 
         # Define all joints in the robot from XACRO
         self.joint_positions = {
@@ -125,7 +128,21 @@ class RobotJointPublisher(Node):
         for thread in threads:
             thread.join()
 
-    def execute_animation(self, animation_file):
+    def execute_animation(self, animation_file=None):
+
+        # If no animation file was provided, parse from parameters
+        if animation_file is None:
+            behavior = self.get_parameter('behavior').get_parameter_value().string_value
+            
+            if ".json" not in behavior:
+                behavior += ".json"
+
+            animation_file = os.path.join(
+                get_package_share_directory(package_name),
+                'behaviors',
+                behavior
+            )
+
         try:
             with open(animation_file, 'r') as f:
                 animation_data = json.load(f)
@@ -155,16 +172,9 @@ def main(args=None):
     rclpy.init(args=args)
     publisher = RobotJointPublisher()
 
-    package_name = 'sami_sim'
-    animation_file = os.path.join(
-        get_package_share_directory(package_name),
-        'behaviors',
-        behavior
-    )
-
     animation_thread = threading.Thread(
         target=publisher.execute_animation,
-        args=(animation_file,),
+        args=(),
         daemon=True
     )
     animation_thread.start()
@@ -179,3 +189,4 @@ def main(args=None):
 
 if __name__ == '__main__':
     main()
+

--- a/sami_sim/scripts/json_joint_publisher.py
+++ b/sami_sim/scripts/json_joint_publisher.py
@@ -18,7 +18,7 @@ class RobotJointPublisher(Node):
         self.publisher = self.create_publisher(JointState, '/joint_states', 10)
 
         # Parameter declaration
-        self.declare_parameter('behavior', 'TEST.json')
+        self.declare_parameter('behavior_file', 'TEST.json')
 
         # Define all joints in the robot from XACRO
         self.joint_positions = {
@@ -132,7 +132,7 @@ class RobotJointPublisher(Node):
 
         # If no animation file was provided, parse from parameters
         if animation_file is None:
-            behavior = self.get_parameter('behavior').get_parameter_value().string_value
+            behavior = self.get_parameter('behavior_file').get_parameter_value().string_value
             
             if ".json" not in behavior:
                 behavior += ".json"


### PR DESCRIPTION
Use ros2 parameters to allow for defining the behavior file at runtime. Animation files can still be passed to the `execute_animation()` method but when no argument for animation_file is passed to the method it will read from the ros2 parameter `behavior_file` and then read that file and load the animation within. Additionally `.json` will be appended to the parameter if it is not already contained in the string.

Use `ros2 run sami_sim json_joint_publisher.py --ros-args -p behavior_file:=<behavior_file_name>` to use. Will default to `TEST.json` if no argument is provided.